### PR TITLE
Feature/split criterions utilities

### DIFF
--- a/docs/src/splitting_criterion.md
+++ b/docs/src/splitting_criterion.md
@@ -2,6 +2,16 @@
 
 This package offers multiple options of splitting criterion for evaluating the quality of a split and therefore constructing a decision tree. In the following a brief overview of the available criterion and their use cases is provided.
 
+You can retrieve a list of the available splitting criterions with the function `get_split_criterions`, like so:
+
+
+```@example 1
+using DecisionTreeAndRandomForest # hide
+println(get_split_criterions())
+println(get_split_criterions("classification"))
+println(get_split_criterions("regression"))
+```
+
 ## Gini Impurity
 Gini Impurity measures the likelihood of an incorrect classification of a randomly chosen element if it is labeled according to the distribution of labels in the dataset. 
 Gini Impurity is primarily used in classification problems. A lower Gini impurity indicates a purer node with a higher confidence in predicting the class label. The goal is to minimize the Gini Impurity at each split, thereby creating nodes that are as pure as possible.

--- a/src/DecisionTree.jl
+++ b/src/DecisionTree.jl
@@ -21,7 +21,7 @@ Represents a Node in the DecisionTree structure.
 $(TYPEDFIELDS)
 """
 mutable struct Node
-    "Points to the left child." 
+    "Points to the left child."
     left::Union{Node,Leaf}
     "Points to the right child."
     right::Union{Node,Leaf}
@@ -134,6 +134,11 @@ This function builds the tree structure of the `DecisionTree` by calling the `bu
 function fit!(tree::DecisionTree, data::AbstractMatrix, labels::AbstractVector)
     if size(data, 1) != length(labels)
         throw(ArgumentError("The number of rows in data must match the number of elements in labels -> $(size(data, 1)) != $(length(labels))"))
+    end
+    if !(eltype(labels) <: Number)
+        if tree.split_criterion in get_split_criterions("regression")
+            throw(ArgumentError("The chosen split criterion does only work for classification task, please choose another one"))
+        end
     end
     tree.root = build_tree(data, labels, tree.max_depth, tree.min_samples_split, tree.num_features, tree.split_criterion, 0)
 end

--- a/src/DecisionTreeAndRandomForest.jl
+++ b/src/DecisionTreeAndRandomForest.jl
@@ -9,7 +9,9 @@ include("RandomForest.jl")
 include("split-criterions/GiniImpurity.jl")
 include("split-criterions/InformationGain.jl")
 include("split-criterions/VarianceReduction.jl")
+include("split-criterions/Utils.jl")
 
 export DecisionTree, RandomForest, fit!, predict
 export split_gini, split_ig, split_variance
+export get_split_criterions
 end

--- a/src/split-criterions/Utils.jl
+++ b/src/split-criterions/Utils.jl
@@ -1,0 +1,22 @@
+"""
+    $(SIGNATURES)
+
+Retrieves the implemented split criterions that can be used.
+
+## Arguments
+- `task::String`: A String that indicates for which task the splitting criterions should be retrieved. Can be `"classification"` or `"regression"`.
+    Defaults to returning all available criterions
+
+## Returns
+- `Tuple{Function}`: A tuple containing the implemented functions.
+  """
+function get_split_criterions(task::String="all")
+    criterions = Dict(
+        "classification" => (split_gini, split_ig),
+        "regression" => (split_variance,)
+    )
+    if task == "classification" || task == "regression"
+        return criterions[task]
+    end
+    return (criterions["classification"]..., criterions["regression"]...)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ using StatsBase: mean
     include("test_classificationtree.jl")
     include("test_randomforest.jl")
     include("test_regressiontree.jl")
+    include("test_splittingcriterionutils.jl")
 end
 
 

--- a/test/test_splittingcriterionutils.jl
+++ b/test/test_splittingcriterionutils.jl
@@ -1,0 +1,6 @@
+@testset "get_split_criterions" begin
+    @test get_split_criterions() == (split_gini, split_ig, split_variance)
+    @test get_split_criterions("42") == (split_gini, split_ig, split_variance)
+    @test get_split_criterions("regression") == (split_variance,)
+    @test get_split_criterions("classification") == (split_gini, split_ig)
+end


### PR DESCRIPTION
I added a little helper function that returns available split criterions, wrote a test and updated the documentation.
DecisionTree now also throws an error when you try to use a regression criterion on a classification tree. The other way around is fine because everything can be classified i guess